### PR TITLE
Renaming to COpenSSL per SPM convention

### DIFF
--- a/OpenSSL/include/module.modulemap
+++ b/OpenSSL/include/module.modulemap
@@ -1,4 +1,4 @@
-module OpenSSL {
+module COpenSSL {
 	header "openssl.h"
 	link "OpenSSL"
 }

--- a/Package.swift
+++ b/Package.swift
@@ -19,4 +19,4 @@
 
 import PackageDescription
 
-let package = Package(name: "OpenSSL")
+let package = Package(name: "COpenSSL")


### PR DESCRIPTION
I'd like to ask the Perfect team to rename the OpenSSL package to COpenSSL.

Per Swift Package Manager's docs:
https://github.com/apple/swift-package-manager/blob/master/Documentation/Usage.md#require-system-libraries

>The convention we hope the community will adopt is to prefix such modules with C and to camelcase the modules as per Swift module name conventions. Then the community is free to name another module simply JPEG which contains more “Swifty” function wrappers around the raw C interface.